### PR TITLE
Add support for concurrently logging messages from different threads.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,4 @@ winapi = "0.2"
 
 [dev-dependencies]
 assert_matches = "1.0"
+rand = "0.3"


### PR DESCRIPTION
This pull request adds a `LogSender` struct which allows other threads to log messages while a prompt is active, without screwing up the prompt.

## Example
<p align="center">
<img src="https://i.imgur.com/AK3xjoX.gif" alt="LogSender demo">
</p>