### PR TITLE
Exposes read-only access to screen_size from Reader.

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -483,6 +483,12 @@ impl<Term: Terminal> Reader<Term> {
         self.move_to(pos)
     }
 
+    /// Returns the size of the terminal at the last draw operation. See
+    /// `Term::size()`.
+    pub fn size(&self) -> Size {
+        self.screen_size
+    }
+
     /// Returns whether a numerical argument was explicitly supplied by the user.
     pub fn explicit_arg(&self) -> bool {
         self.explicit_arg

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -485,7 +485,7 @@ impl<Term: Terminal> Reader<Term> {
 
     /// Returns the size of the terminal at the last draw operation. See
     /// `Term::size()`.
-    pub fn size(&self) -> Size {
+    pub fn screen_size(&self) -> Size {
         self.screen_size
     }
 


### PR DESCRIPTION
This is useful when using screen-size-aware formatting, e.g. [Wadler pretty-print combinators](https://homepages.inf.ed.ac.uk/wadler/papers/prettier/prettier.pdf).