### PR TITLE
Add ability to avoid dependency on ncurses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,11 @@ keywords = ["console", "terminal", "input", "readline"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 
+[features]
+default = ["deafult-terminal"]
+# Includes `DeafultTerminal` in the crate and makes it dependent on `libncursesw`
+deafult-terminal = []
+
 [badges]
 travis-ci = { repository = "murarth/linefeed" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,3 +39,19 @@ winapi = "0.2"
 [dev-dependencies]
 assert_matches = "1.0"
 rand = "0.3"
+
+[[example]]
+name = "demo"
+required-features = ["include-deafult-terminal"]
+
+[[example]]
+name = "function"
+required-features = ["include-deafult-terminal"]
+
+[[example]]
+name = "path_completion"
+required-features = ["include-deafult-terminal"]
+
+[[example]]
+name = "signals"
+required-features = ["include-deafult-terminal"]

--- a/README.md
+++ b/README.md
@@ -27,7 +27,14 @@ linefeed = "0.4"
 
 ### Dependencies
 
-On Unix systems, `linefeed` requires `libncursesw` (`libncurses` on Mac OS X).
+On Unix systems, `linefeed` requires `libncursesw` (`libncurses` on Mac OS X) to
+implement `DefaultTerminal`. But if you use your own implementation of `Terminal`,
+you can exclude `DefaultTerminal` from `linefeed` and avoid dependency:
+
+```toml
+[dependencies]
+linefeed = { version = "0.4", default-features = false }
+```
 
 ### Demo
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,10 @@ pub use command::Command;
 pub use complete::{Completer, Completion, Suffix};
 pub use function::Function;
 pub use reader::{Reader, ReadResult};
-pub use terminal::{DefaultTerminal, Signal, Terminal};
+pub use terminal::{Signal, Terminal};
+
+#[cfg(feature = "deafult-terminal")]
+pub use terminal::DefaultTerminal;
 
 pub mod chars;
 pub mod command;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! # Basic example
 //!
-//! ```no_run
+//! ```ignore
 //! use linefeed::{Reader, ReadResult};
 //!
 //! let mut reader = Reader::new("my-application").unwrap();

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -25,8 +25,11 @@ use function::Function;
 use inputrc::{parse_file, Directive};
 use sys::path::{env_init_file, system_init_file, user_init_file};
 use table::{format_columns, Table};
-use terminal::{CursorMode, DefaultTerminal, Signal, SignalSet, Size, Terminal};
+use terminal::{CursorMode, Signal, SignalSet, Size, Terminal};
 use util::{longest_common_prefix, RangeArgument};
+
+#[cfg(feature = "deafult-terminal")]
+use terminal::DefaultTerminal;
 
 /// Default `keyseq_timeout`, in milliseconds
 pub const KEYSEQ_TIMEOUT_MS: u64 = 500;
@@ -228,6 +231,7 @@ pub struct Reader<Term: Terminal> {
     poll_log_interval: Duration,
 }
 
+#[cfg(feature = "deafult-terminal")]
 impl Reader<DefaultTerminal> {
     /// Creates a new `Reader` with the given application name.
     ///

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -3,6 +3,7 @@
 use std::io;
 use std::time::Duration;
 
+#[cfg(feature = "deafult-terminal")]
 use sys;
 
 /// Terminal cursor mode
@@ -87,6 +88,7 @@ pub struct Size {
 }
 
 /// Type alias for the platform-dependent default `Terminal` interface
+#[cfg(feature = "deafult-terminal")]
 pub type DefaultTerminal = sys::Terminal;
 
 /// Defines a low-level interface to the terminal

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -1,7 +1,11 @@
 //! Unix platform support
 
+#[cfg(feature = "deafult-terminal")]
 pub use self::terminal::UnixTerminal as Terminal;
 
 pub mod path;
+
+#[cfg(feature = "deafult-terminal")]
 mod terminal;
+#[cfg(feature = "deafult-terminal")]
 mod terminfo;

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -1,6 +1,8 @@
 //! Windows platform support
 
+#[cfg(feature = "deafult-terminal")]
 pub type Terminal = console::Console;
 
+#[cfg(feature = "deafult-terminal")]
 mod console;
 pub mod path;


### PR DESCRIPTION
There's no need in ncurses if I have my own implementation of `Terminal`.

I've made feature `default-terminal` which includes `DefaultTerminal` in the crate and marked this feature as default.