### PR TITLE
Add method for connecting to tty instead of stdout

### DIFF
--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -165,6 +165,12 @@ impl DefaultTerminal {
         mortal::Terminal::new().map(DefaultTerminal)
     }
 
+    /// Unix only.  
+    /// Opens access to the terminal device associated with a tty path
+    pub fn new_path(path: String) -> io::Result<DefaultTerminal> {
+        mortal::unix::OpenTerminalExt::from_path(path).map(DefaultTerminal)
+    }
+
     /// Opens access to the terminal device associated with standard error.
     pub fn stderr() -> io::Result<DefaultTerminal> {
         mortal::Terminal::stderr().map(DefaultTerminal)

--- a/src/terminal.rs
+++ b/src/terminal.rs
@@ -165,6 +165,7 @@ impl DefaultTerminal {
         mortal::Terminal::new().map(DefaultTerminal)
     }
 
+    #[cfg(any(unix))]
     /// Unix only.  
     /// Opens access to the terminal device associated with a tty path
     pub fn new_path(path: String) -> io::Result<DefaultTerminal> {


### PR DESCRIPTION
In order to hand a tty to mortal I needed to call this function.   Unfortunately DefaultTerminal has private members that makes instantiating it impossible outside of the module.  

I don't like putting Unix specific calls at the top level.  However, I was able to get this to work and have successfully connected a multi-threaded CLI to my project without using fork() to change stdout.

Hoping that this or something similar gets added into the repository to allow overriding stdout/stderr.